### PR TITLE
Use next/link for links

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function About(){
+  return(
+    <div>
+      <p>This is the About Page</p>
+      <Link href="/">
+        Home
+      </Link>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { Box, Button, Typography } from "@mui/material";
+import Link from "next/link";
 import { ResizableBox } from "react-resizable";
 
 export default function Home() {
@@ -10,6 +11,9 @@ export default function Home() {
         <Button variant="contained" onClick={() => window.alert('clicked')}>
           Test
         </Button>
+        <Link href="/about">
+          About
+        </Link>
       </Box>
     </main>
   );

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -7,6 +7,7 @@ import { FileDownloadOutlined } from "@mui/icons-material";
 import { DNALogo } from "logots-react";
 import { getFileSize } from "./helpers";
 import { useState, useEffect, useMemo } from "react";
+import Link from "next/link"
 
 const Figure = (figure: FactorChatFigure) => {
   switch (figure.type) {
@@ -42,11 +43,7 @@ export const Message = (message: FactorChatMessage) => {
         overrides={{
           ...getOverrides({}),
           a: {
-            component: 'a',
-            props : {
-              rel: "noopener noreferrer",
-              target: "_blank"
-            }
+            component: Link, //override <a> with Next.js <Link> to avoid hard navigation (resets chatbot state)
           }
         }}
       >

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,5 +1,5 @@
 import Markdown from "react-markdown" //todo remove one of these depending on which I decide to use
-import { MuiMarkdown } from 'mui-markdown'; //https://www.npmjs.com/package/mui-markdown
+import { getOverrides, MuiMarkdown } from 'mui-markdown'; //https://www.npmjs.com/package/mui-markdown
 import { MessageBubble } from "./MessageBubble"
 import { FactorChatFigure, FactorChatMessage } from "./types"
 import { Alert, Button, Typography } from "@mui/material";
@@ -38,7 +38,18 @@ export const Message = (message: FactorChatMessage) => {
 
   return (
     <MessageBubble isUser={isUser}>
-      <MuiMarkdown>
+      <MuiMarkdown
+        overrides={{
+          ...getOverrides({}),
+          a: {
+            component: 'a',
+            props : {
+              rel: "noopener noreferrer",
+              target: "_blank"
+            }
+          }
+        }}
+      >
         {contents}
       </MuiMarkdown>
       {figures.length > 0 && figures.map((figure, i) =>

--- a/src/components/exampleResponse.ts
+++ b/src/components/exampleResponse.ts
@@ -1,4 +1,4 @@
-import { BackendMessage, FactorChatMessage, FactorChatResponse } from '@/components/types'
+import { FactorChatResponse } from '@/components/types'
 
 const examapleMD: string = `
 # Markdown: Syntax

--- a/src/components/useFactorChat.ts
+++ b/src/components/useFactorChat.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { FactorChatMessage, FactorChatResponse } from "./types";
+import { exampleResponse } from "./exampleResponse";
 
 export function useFactorChat() {
   const [messages, setMessages] = useState<FactorChatMessage[]>([])
@@ -37,7 +38,8 @@ export function useFactorChat() {
       const backendMessage: FactorChatResponse = await res.json()
 
       setMessages([...newMessages, {origin: "backend", contents: backendMessage}])
-    
+      // setMessages([...newMessages, {origin: "backend", contents: exampleResponse}])
+      
     } catch (error) {
       console.error('Error:\n', error)
       const errorMsg: FactorChatResponse = {

--- a/src/components/useFactorChat.ts
+++ b/src/components/useFactorChat.ts
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { FactorChatMessage, FactorChatResponse } from "./types";
-import { exampleResponse } from "@/components/exampleResponse";
 
 export function useFactorChat() {
   const [messages, setMessages] = useState<FactorChatMessage[]>([])
@@ -27,7 +26,6 @@ export function useFactorChat() {
     try {
       setLoading(true)
 
-      // for sending POST with payload. Might need to modify headers or how the body is sent, not sure
       const res = await fetch('http://localhost:5000/api/chat', {
         method: "POST",
         headers: {
@@ -36,7 +34,6 @@ export function useFactorChat() {
         body: JSON.stringify(newMessages)
       })
 
-      // Should change this to the type "FactorChatResponse" when receiving response from actual backend. See types.ts for definition
       const backendMessage: FactorChatResponse = await res.json()
 
       setMessages([...newMessages, {origin: "backend", contents: backendMessage}])
@@ -50,9 +47,6 @@ export function useFactorChat() {
       }
       setMessages([...newMessages, {origin: "backend", contents: errorMsg}])
     }
-
-    // For using example response
-    // setMessages([...newMessages, { origin: "backend", contents: exampleResponse }])
     
     setLoading(false)
   }


### PR DESCRIPTION
Overrides <a> with <Link> from next/link to enable soft navigation internally. Links must be relative (no https://)  to be internal. Soft navigation allows for the chatbot state to be preserved when navigating internally